### PR TITLE
Remove duplicate license declaration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,6 @@
         }
     },
     "keywords": [ "Actively maintained" ],
-    "license": "GPL-2.0-or-later",
     "authors": [
         {
             "name": "Cottser",


### PR DESCRIPTION
Composer throws a warning that made me notice this one "Key license is a duplicate in ./composer.json at line 12"